### PR TITLE
enable output filtering in tracing-ndjson

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -6,6 +6,8 @@ use tracing_subscriber::{registry::LookupSpan, Layer};
 
 use crate::{storage::JsonStorage, TimestampFormat};
 
+type FieldFilter = Box<dyn Fn(&str) -> bool + Send + Sync>;
+
 pub struct JsonFormattingLayer {
     pub(crate) level_name: &'static str,
     pub(crate) level_value_casing: crate::Casing,
@@ -17,6 +19,7 @@ pub struct JsonFormattingLayer {
     pub(crate) file_names: bool,
     pub(crate) flatten_fields: bool,
     pub(crate) flatten_spans: bool,
+    pub(crate) field_filter: Option<FieldFilter>,
 }
 
 impl Default for JsonFormattingLayer {
@@ -32,6 +35,7 @@ impl Default for JsonFormattingLayer {
             file_names: false,
             flatten_fields: true,
             flatten_spans: true,
+            field_filter: None,
         }
     }
 }
@@ -129,8 +133,14 @@ where
         }
 
         // Serialize the event fields
+        let should_include =
+            |name: &str| self.field_filter.as_ref().is_none_or(|f| f(name));
+
         if self.flatten_fields {
             visitor.values().iter().for_each(|(k, v)| {
+                if !should_include(k) {
+                    return;
+                }
                 if *k == "message" {
                     root.insert(self.message_name, v.clone());
                 } else {
@@ -140,6 +150,9 @@ where
         } else {
             let mut fields = HashMap::new();
             visitor.values().iter().for_each(|(k, v)| {
+                if !should_include(k) {
+                    return;
+                }
                 if *k == "message" {
                     fields.insert(self.message_name, v.clone());
                 } else {
@@ -158,6 +171,9 @@ where
                 let visitor = ext.get::<crate::storage::JsonStorage>();
                 if let Some(visitor) = visitor {
                     visitor.values().iter().for_each(|(k, v)| {
+                        if !should_include(k) {
+                            return;
+                        }
                         if *k == "message" {
                             fields.insert(self.message_name, v.clone());
                         } else {
@@ -175,6 +191,9 @@ where
             if self.flatten_spans {
                 spans.iter().for_each(|fields| {
                     fields.iter().for_each(|(k, v)| {
+                        if !should_include(k) {
+                            return;
+                        }
                         if *k == "message" {
                             root.insert(self.message_name, v.clone());
                         } else {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -40,6 +40,24 @@ impl Default for JsonFormattingLayer {
     }
 }
 
+impl JsonFormattingLayer {
+    fn insert_fields<'k: 'v, 'v>(
+        &self,
+        source: impl Iterator<Item = (&'v &'k str, &'v serde_json::Value)>,
+        dest: &mut HashMap<&'k str, serde_json::Value>,
+    ) {
+        for (&k, v) in source {
+            if let Some(ref f) = self.field_filter {
+                if !f(k) {
+                    continue;
+                }
+            }
+            let key = if k == "message" { self.message_name } else { k };
+            dest.insert(key, v.clone());
+        }
+    }
+}
+
 impl<S> Layer<S> for JsonFormattingLayer
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
@@ -133,32 +151,11 @@ where
         }
 
         // Serialize the event fields
-        let should_include =
-            |name: &str| self.field_filter.as_ref().is_none_or(|f| f(name));
-
         if self.flatten_fields {
-            visitor.values().iter().for_each(|(k, v)| {
-                if !should_include(k) {
-                    return;
-                }
-                if *k == "message" {
-                    root.insert(self.message_name, v.clone());
-                } else {
-                    root.insert(k, v.clone());
-                }
-            });
+            self.insert_fields(visitor.values().iter(), &mut root);
         } else {
             let mut fields = HashMap::new();
-            visitor.values().iter().for_each(|(k, v)| {
-                if !should_include(k) {
-                    return;
-                }
-                if *k == "message" {
-                    fields.insert(self.message_name, v.clone());
-                } else {
-                    fields.insert(k, v.clone());
-                }
-            });
+            self.insert_fields(visitor.values().iter(), &mut fields);
             root.insert("fields", json!(fields));
         }
 
@@ -170,16 +167,7 @@ where
                 let ext = span.extensions();
                 let visitor = ext.get::<crate::storage::JsonStorage>();
                 if let Some(visitor) = visitor {
-                    visitor.values().iter().for_each(|(k, v)| {
-                        if !should_include(k) {
-                            return;
-                        }
-                        if *k == "message" {
-                            fields.insert(self.message_name, v.clone());
-                        } else {
-                            fields.insert(k, v.clone());
-                        }
-                    });
+                    self.insert_fields(visitor.values().iter(), &mut fields);
                 }
                 if !fields.is_empty() {
                     spans.push(fields);
@@ -189,18 +177,9 @@ where
 
         if !spans.is_empty() {
             if self.flatten_spans {
-                spans.iter().for_each(|fields| {
-                    fields.iter().for_each(|(k, v)| {
-                        if !should_include(k) {
-                            return;
-                        }
-                        if *k == "message" {
-                            root.insert(self.message_name, v.clone());
-                        } else {
-                            root.insert(k, v.clone());
-                        }
-                    });
-                });
+                for fields in &spans {
+                    self.insert_fields(fields.iter(), &mut root);
+                }
             } else {
                 root.insert("spans", json!(spans));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,17 @@ impl Builder {
         self
     }
 
+    /// Set a predicate that controls which fields appear in the JSON output.
+    /// Fields for which the predicate returns `false` are omitted from output
+    /// but are still recorded in span storage and visible to other layers.
+    pub fn with_field_filter(
+        mut self,
+        filter: impl Fn(&str) -> bool + Send + Sync + 'static,
+    ) -> Self {
+        self.layer.field_filter = Some(Box::new(filter));
+        self
+    }
+
     pub fn layer<S>(self) -> impl tracing_subscriber::Layer<S>
     where
         S: Subscriber + for<'a> LookupSpan<'a>,
@@ -375,6 +386,33 @@ mod tests {
             });
 
             some_function(1, 2);
+        });
+    }
+
+    #[test]
+    fn test_field_filter() {
+        let subscriber = tracing_subscriber::registry().with(
+            builder()
+                .with_field_filter(|name| !name.starts_with("__"))
+                .layer(),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            info!(
+                __sentry_fn = "MyService::handle",
+                __sentry_label = "request failed",
+                correlation_id = "abc-123",
+                "something went wrong"
+            );
+
+            let span = info_span!(
+                "request",
+                __internal = "hidden",
+                request_id = "req-456",
+            );
+            span.in_scope(|| {
+                info!("processing request");
+            });
         });
     }
 }


### PR DESCRIPTION
tracing_subscriber json allowed filtering through its fmt_fields builder method. This commit adds the capability to filter out certain fields from tracing_ndjson's output.